### PR TITLE
Fixed link to histomap

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Picography
 
-Inspired by [Rand McNally's histomap](www.slate.com/features/2013/08/histomapwider.jpg), picography allows you to visualise and share a personal history.
+Inspired by [Rand McNally's histomap](http://www.slate.com/features/2013/08/histomapwider.jpg), picography allows you to visualise and share a personal history.
 
 What it does:
 * Helps you craft narrative and meaning out of your past.


### PR DESCRIPTION
Github needs to be given a URL scheme to know that it shouldn't link to things within the repo. This PR adds a `http://` before the link to the histogram (http because there seems to be a problem with the certificate if we use https).

Cheers