### PR TITLE
make_pico: set up the global options

### DIFF
--- a/picography.py
+++ b/picography.py
@@ -594,6 +594,10 @@ def make_pico(func, argv):
 
     args = collect_args(argv)
 
+    # Allow convenient access of dictionary values (dict.key)
+    global options
+    options = TypedAttrDict(timeline_options)
+
     if args.tsv:
         setup_dwg('')
         func()


### PR DESCRIPTION
timespan() is dependent on the global options.
We want to allow timespan() to be called within func(), so we need to
initialize the global variable accordingly.